### PR TITLE
fix: inject maxDataPoints and intervalMs into panel queries to match Grafana UI results

### DIFF
--- a/pkg/grafanadata/grafanadata_test.go
+++ b/pkg/grafanadata/grafanadata_test.go
@@ -50,7 +50,7 @@ func CreateMockGrafanaClient(t *testing.T, mockClient *MockHTTPClient) *Client {
 }
 
 func TestCreateGrafanaClient(t *testing.T) {
-	_, err := NewGrafanaClient("foo", "bar")
+	_, err := NewGrafanaClient("foo", WithToken("bar"))
 	if err != nil {
 		t.Fatalf("creating new grafana Client error %v", err)
 	}
@@ -155,7 +155,6 @@ func TestGetDashboards(t *testing.T) {
 }
 
 func TestVariousGrafanaUrls(t *testing.T) {
-	token := "foo"
 	urls := []string{
 		"http://grafana:3000",
 		"http://grafana:3000/",
@@ -166,7 +165,7 @@ func TestVariousGrafanaUrls(t *testing.T) {
 	}
 
 	for _, url := range urls {
-		client, err := NewGrafanaClient(url, token)
+		client, err := NewGrafanaClient(url, WithToken("foo"))
 		if err != nil {
 			t.Fatalf("could not created GrafanaClient from %v: %v", url, err)
 		}
@@ -175,5 +174,78 @@ func TestVariousGrafanaUrls(t *testing.T) {
 		if host != strings.TrimSuffix(url, "/") {
 			t.Errorf("expected %v. got %v", url, host)
 		}
+	}
+}
+
+func TestParseIntervalMs(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"1m", 60000},
+		{"5m", 300000},
+		{"2m", 120000},
+		{"30s", 30000},
+		{"1h", 3600000},
+		{"1d", 86400000},
+		{"", 0},                           // empty → no interval configured, return 0
+		{"invalid", defaultIntervalMs},    // non-empty but unparseable → fallback default
+		{"m", defaultIntervalMs},          // too short, non-empty → fallback default
+		{"0m", 0},                         // zero value parses correctly to 0ms
+		{"3x", defaultIntervalMs},         // unknown unit → fallback default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := parseIntervalMs(tt.input)
+			if result != tt.expected {
+				t.Errorf("parseIntervalMs(%q) = %d, want %d", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetPanelDataInjectsMaxDataPoints(t *testing.T) {
+	// loading in the dashboard
+	client := CreateMockClient(t, "dashboard.json", http.StatusOK)
+	g := CreateMockGrafanaClient(t, client)
+
+	dashboard, err := g.getDashboard("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set panel interval to verify it gets parsed
+	dashboard.Dashboard.Panels[1].Interval = "2m"
+
+	// Use a mock that captures the request body
+	var capturedBody []byte
+	g.client = &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			capturedBody, _ = io.ReadAll(req.Body)
+
+			file, err := os.Open("./test/data.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(file),
+			}, nil
+		},
+	}
+
+	_, err = g.getPanelData(2, dashboard, WithTimeRange(time.Now(), time.Time{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that maxDataPoints and intervalMs were injected
+	bodyStr := string(capturedBody)
+	if !strings.Contains(bodyStr, "\"maxDataPoints\"") {
+		t.Error("expected maxDataPoints to be injected into query targets")
+	}
+	if !strings.Contains(bodyStr, "\"intervalMs\"") {
+		t.Error("expected intervalMs to be injected into query targets")
 	}
 }

--- a/pkg/grafanadata/model.go
+++ b/pkg/grafanadata/model.go
@@ -48,11 +48,13 @@ type Dashboard struct {
 }
 
 type Panel struct {
-	ID         int        `json:"id"`
-	Datasource Datasource `json:"datasource"`
-	Targets    []any      `json:"targets"`
-	Title      string     `json:"title"`
-	Panels     []Panel    `json:"panels"` // for nested panels
+	ID            int        `json:"id"`
+	Datasource    Datasource `json:"datasource"`
+	Targets       []any      `json:"targets"`
+	Title         string     `json:"title"`
+	Panels        []Panel    `json:"panels"`        // for nested panels
+	Interval      string     `json:"interval"`       // minimum query interval, e.g. "1m", "5m"
+	MaxDataPoints *int       `json:"maxDataPoints"`  // max data points for the panel query
 }
 
 type Datasource struct {


### PR DESCRIPTION


Without these fields, Grafana's /api/ds/query endpoint defaults to ~100 data points, causing $__interval to resolve to ~15m instead of ~1m for a 1-day range. This produces significantly different (lower) values for expressions using max_over_time/rate subqueries compared to what users see in the Grafana dashboard.

Read the panel's interval and maxDataPoints fields from the dashboard JSON and inject them into each query target. Default maxDataPoints to 1000 (matching typical Grafana UI panel width) when not explicitly set.