### PR TITLE
fix: handle multi-value template variable current.text as any +  add FieldConfig to Panel

### DIFF
--- a/pkg/grafanadata/model.go
+++ b/pkg/grafanadata/model.go
@@ -55,12 +55,21 @@ type Panel struct {
 	Panels        []Panel    `json:"panels"`        // for nested panels
 	Interval      string     `json:"interval"`      // minimum query interval, e.g. "1m", "5m"
 	MaxDataPoints *int       `json:"maxDataPoints"` // max data points for the panel query
+	FieldConfig   FieldConfig `json:"fieldConfig"`
 }
 
 type Datasource struct {
 	Type      string `json:"type"`
 	UID       string `json:"uid"`
 	IsDefault bool   `json:"isDefault,omitempty"`
+}
+
+type FieldConfig struct {
+	Defaults FieldDefaults `json:"defaults"`
+}
+
+type FieldDefaults struct {
+	Unit string `json:"unit"`
 }
 
 type Target struct {

--- a/pkg/grafanadata/model.go
+++ b/pkg/grafanadata/model.go
@@ -48,13 +48,13 @@ type Dashboard struct {
 }
 
 type Panel struct {
-	ID            int        `json:"id"`
-	Datasource    Datasource `json:"datasource"`
-	Targets       []any      `json:"targets"`
-	Title         string     `json:"title"`
-	Panels        []Panel    `json:"panels"`        // for nested panels
-	Interval      string     `json:"interval"`      // minimum query interval, e.g. "1m", "5m"
-	MaxDataPoints *int       `json:"maxDataPoints"` // max data points for the panel query
+	ID            int         `json:"id"`
+	Datasource    Datasource  `json:"datasource"`
+	Targets       []any       `json:"targets"`
+	Title         string      `json:"title"`
+	Panels        []Panel     `json:"panels"`        // for nested panels
+	Interval      string      `json:"interval"`      // minimum query interval, e.g. "1m", "5m"
+	MaxDataPoints *int        `json:"maxDataPoints"` // max data points for the panel query
 	FieldConfig   FieldConfig `json:"fieldConfig"`
 }
 

--- a/pkg/grafanadata/model.go
+++ b/pkg/grafanadata/model.go
@@ -40,8 +40,8 @@ type Dashboard struct {
 			Datasource Datasource `json:"datasource"`
 			Query      any        `json:"query"`
 			Current    struct {
-				Text  string `json:"text"`
-				Value any    `json:"value"`
+				Text  any `json:"text"`
+				Value any `json:"value"`
 			} `json:"current"`
 		} `json:"list"`
 	} `json:"templating"`
@@ -53,8 +53,8 @@ type Panel struct {
 	Targets       []any      `json:"targets"`
 	Title         string     `json:"title"`
 	Panels        []Panel    `json:"panels"`        // for nested panels
-	Interval      string     `json:"interval"`       // minimum query interval, e.g. "1m", "5m"
-	MaxDataPoints *int       `json:"maxDataPoints"`  // max data points for the panel query
+	Interval      string     `json:"interval"`      // minimum query interval, e.g. "1m", "5m"
+	MaxDataPoints *int       `json:"maxDataPoints"` // max data points for the panel query
 }
 
 type Datasource struct {


### PR DESCRIPTION
Grafana serializes current.text as []string (e.g. ["All"]) when a template variable has multi=true. Previously this crashed unmarshaling into string. Widening to any accepts both string and []string.

Bug fix:

Widened TemplateVariable.Current.Text from string to any to accept both string and []string serializations from Grafana

Model extension:

Added `FieldConfig` and `FieldDefaults` types to capture panel-level field configuration
Wired FieldConfig into the Panel struct, exposing fieldConfig.defaults.unit (e.g. "bytes", "percent") for downstream consumers that need unit metadata per panel.
