### PR TITLE
feat: add HTTPError type for non-200 Grafana API responses (WH-4113)

### DIFF
--- a/pkg/grafanadata/dashboard.go
+++ b/pkg/grafanadata/dashboard.go
@@ -29,7 +29,7 @@ func (c *Client) FetchDashboards() ([]DashboardSearch, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("grafana response %v. %v", resp.StatusCode, string(body))
+		return nil, &HTTPError{StatusCode: resp.StatusCode, Body: string(body)}
 	}
 
 	var search []DashboardSearch

--- a/pkg/grafanadata/grafanadata.go
+++ b/pkg/grafanadata/grafanadata.go
@@ -173,8 +173,7 @@ func (c *Client) getDashboard(uid string) (DashboardResponse, error) {
 	c.log.Debug("got dashboard response", "status", resp.StatusCode, "body", string(b))
 
 	if resp.StatusCode != http.StatusOK {
-		return response, fmt.Errorf("grafana returned status %v; body: %s", resp.StatusCode,
-			string(b))
+		return response, &HTTPError{StatusCode: resp.StatusCode, Body: string(b)}
 	}
 
 	err = json.Unmarshal(b, &response)
@@ -346,7 +345,7 @@ func (c *Client) getPanelData(panelID int, dashboard DashboardResponse, opts ...
 	c.log.Debug("got panel data response", "status", resp.StatusCode, "body", string(b))
 
 	if resp.StatusCode != http.StatusOK {
-		return result, fmt.Errorf("grafana returned status %v; body: %s", resp.StatusCode, string(b))
+		return result, &HTTPError{StatusCode: resp.StatusCode, Body: string(b)}
 	}
 
 	err = json.Unmarshal(b, &result)
@@ -490,13 +489,13 @@ func (c *Client) getLabelValues(ds, query string, options panelOptions) ([]strin
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("grafana returned status %d", resp.StatusCode)
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &HTTPError{StatusCode: resp.StatusCode, Body: string(body)}
 	}
 
 	var labelResponse struct {
@@ -545,7 +544,7 @@ func (c *Client) getDefaultDatasource() (Datasource, error) {
 	c.log.Debug("got datasources response", "status", resp.StatusCode, "body", string(b))
 
 	if resp.StatusCode != http.StatusOK {
-		return c.defaultDatasource, fmt.Errorf("grafana returned status %v; body: %s", resp.StatusCode, string(b))
+		return c.defaultDatasource, &HTTPError{StatusCode: resp.StatusCode, Body: string(b)}
 	}
 
 	var datasources []Datasource

--- a/pkg/grafanadata/model.go
+++ b/pkg/grafanadata/model.go
@@ -1,5 +1,18 @@
 package grafanadata
 
+import "fmt"
+
+// HTTPError is returned when the Grafana API responds with a non-200 status code.
+// Callers can use errors.As to extract the status code and mirror it upstream.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("grafana returned status %d; body: %s", e.StatusCode, e.Body)
+}
+
 //////////////////////////////////////////////////
 // The important parts of a Grafana dashboard json
 //////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

- Adds exported `HTTPError` struct to `pkg/grafanadata/model.go` with `StatusCode int` and `Body string` fields
- Replaces plain `fmt.Errorf` strings with `*HTTPError` on all non-200 HTTP responses across `getDashboard`, `getPanelData`, `getLabelValues`, `getDefaultDatasource`, and `FetchDashboards`

## Backwards compatibility

Fully backwards compatible. `*HTTPError` implements the `error` interface so any caller checking `err != nil` or calling `err.Error()` is unaffected. New callers can use `errors.As` to extract the status code and mirror it upstream rather than returning a generic 500.

## Usage

```go
var httpErr *grafanadata.HTTPError
if errors.As(err, &httpErr) {
    // mirror httpErr.StatusCode back to the caller
}
```